### PR TITLE
fix: Correct line in hyperlink to swapAndAddLiquidity

### DIFF
--- a/v3-sdk/swap-and-add-liquidity/README.md
+++ b/v3-sdk/swap-and-add-liquidity/README.md
@@ -4,7 +4,7 @@
 
 This is an example that demonstrates how to swap between currencies and add those currencies to a liquidity pool in the same transaction that includes running against mainnet, locally, and using a wallet connection.
 
-The core functionality of this example can be found in [`swapAndAddLiquidity`](./src/libs/liquidity.ts#L36).
+The core functionality of this example can be found in [`swapAndAddLiquidity`](./src/libs/liquidity.ts#L48).
 
 ## Configuration
 


### PR DESCRIPTION
# Motivation

The current hyperlink in `v3-sdk/swap-and-add-liquidity/README.md` links to the wrong line in a file.

# Changes

Update the code line in hyperlink.