### PR TITLE
fix: toReadableAmount Slicing cuts after first 4 characters

### DIFF
--- a/v3-sdk/quoting/src/libs/conversion.ts
+++ b/v3-sdk/quoting/src/libs/conversion.ts
@@ -10,7 +10,5 @@ export function fromReadableAmount(
 }
 
 export function toReadableAmount(rawAmount: number, decimals: number): string {
-  return ethers.utils
-    .formatUnits(rawAmount, decimals)
-    .slice(0, READABLE_FORM_LEN)
+  return (+ethers.utils.formatUnits(rawAmount, decimals).toString()).toFixed(READABLE_FORM_LEN)
 }

--- a/v3-sdk/quoting/src/libs/conversion.ts
+++ b/v3-sdk/quoting/src/libs/conversion.ts
@@ -10,5 +10,7 @@ export function fromReadableAmount(
 }
 
 export function toReadableAmount(rawAmount: number, decimals: number): string {
-  return (+ethers.utils.formatUnits(rawAmount, decimals).toString()).toFixed(READABLE_FORM_LEN)
+  return (+ethers.utils.formatUnits(rawAmount, decimals).toString()).toFixed(
+    READABLE_FORM_LEN
+  )
 }


### PR DESCRIPTION
The Quoting example formats the output readable amount with a bad slice.

Modified to send fixed amount decimals.

<img width="788" alt="React_App" src="https://github.com/Uniswap/examples/assets/60412342/a3b37ec9-6832-4f77-b17b-1cf9d67e2c13">
