### PR TITLE
V3 Quoting Example Fixes

### DIFF
--- a/v3-sdk/quoting/src/libs/conversion.ts
+++ b/v3-sdk/quoting/src/libs/conversion.ts
@@ -1,6 +1,6 @@
 import { BigNumber, ethers } from 'ethers'
 
-const READABLE_FORM_LEN = 4
+const MAX_DECIMALS = 4
 
 export function fromReadableAmount(
   amount: number,
@@ -10,7 +10,9 @@ export function fromReadableAmount(
 }
 
 export function toReadableAmount(rawAmount: number, decimals: number): string {
-  return ethers.utils
-    .formatUnits(rawAmount, decimals)
-    .slice(0, READABLE_FORM_LEN)
+  const str = ethers.utils.formatUnits(rawAmount, decimals)
+  return Number(str).toLocaleString(navigator.languages, {
+    maximumFractionDigits: MAX_DECIMALS,
+    minimumFractionDigits: 0,
+  })
 }

--- a/v3-sdk/quoting/src/libs/quote.ts
+++ b/v3-sdk/quoting/src/libs/quote.ts
@@ -19,8 +19,8 @@ export async function quote(): Promise<string> {
   const poolConstants = await getPoolConstants()
 
   const quotedAmountOut = await quoterContract.callStatic.quoteExactInputSingle(
-    poolConstants.token0,
-    poolConstants.token1,
+    CurrentConfig.tokens.in.address,
+    CurrentConfig.tokens.out.address,
     poolConstants.fee,
     fromReadableAmount(
       CurrentConfig.tokens.amountIn,


### PR DESCRIPTION
While playing with the config in this example, I ran into some problems when I swapped the in and out tokens in `config.ts`. I changed the `in` token to `WETH_TOKEN` and the out token to `USDC_TOKEN` and I got an obviously wrong quote (it was something like 1250 USDC out for 1000 WETH in).

There were two problems:

1. The code was calling `quoteExactInputSingle` with `token0` (the token that sorts lower) as the first argument, and `token1` (the token that sorts higher) as the second argument. But according to [the docs](https://docs.uniswap.org/contracts/v3/reference/periphery/lens/Quoter) that's not correct. The first argument should be the in token and the second should be the out token:

![image](https://github.com/user-attachments/assets/e1bbe540-31f7-4fad-a603-a329d08eedbb)

2. After fixing that, I still got an unlikely answer, and I found it's because the answer is truncated to just four characters. I updated it to use standard locale-conscious number formatting and now I get a believable quote:

![image](https://github.com/user-attachments/assets/622a2071-5f76-4898-975d-78b732f727ce)

