### PR TITLE
Change account check from 1 to less than 1

### DIFF
--- a/v3-sdk/minting-position/src/libs/providers.ts
+++ b/v3-sdk/minting-position/src/libs/providers.ts
@@ -58,7 +58,7 @@ export async function connectBrowserExtensionWallet() {
   const provider = new ethers.providers.Web3Provider(ethereum)
   const accounts = await provider.send('eth_requestAccounts', [])
 
-  if (accounts.length !== 1) {
+  if (accounts.length < 1) {
     return
   }
 


### PR DESCRIPTION
`eth_accounts` now returns the full list of accounts for which the user has permitted access to. See the note here https://docs.metamask.io/wallet/how-to/access-accounts#handle-accounts